### PR TITLE
Remove DeFi fork restrictions

### DIFF
--- a/src/bigbang/core.cpp
+++ b/src/bigbang/core.cpp
@@ -620,14 +620,6 @@ Errno CCoreProtocol::ValidateOrigin(const CBlock& block, const CProfile& parentP
         {
             return DEBUG(ERR_BLOCK_INVALID_FORK, "DeFi fork mint halvecycle must be zero");
         }
-        if (forkProfile.hashParent != GetGenesisBlockHash())
-        {
-            return DEBUG(ERR_BLOCK_INVALID_FORK, "DeFi fork must be the direct child fork of main fork");
-        }
-        if (!forkProfile.IsIsolated())
-        {
-            return DEBUG(ERR_BLOCK_INVALID_FORK, "DeFi fork must be the isolated fork");
-        }
 
         const CDeFiProfile& defi = forkProfile.defi;
         if (defi.nMintHeight >= 0 && forkProfile.defi.nMintHeight < forkProfile.nJointHeight + 2)

--- a/src/bigbang/rpcmod.cpp
+++ b/src/bigbang/rpcmod.cpp
@@ -2394,15 +2394,6 @@ CRPCResultPtr CRPCMod::RPCMakeOrigin(CRPCParamPtr param)
             throw CRPCException(RPC_INVALID_PARAMETER, "DeFi fork mint halvecycle must be zero");
         }
 
-        if (hashParent != pCoreProtocol->GetGenesisBlockHash())
-        {
-            throw CRPCException(RPC_INVALID_PARAMETER, "DeFi fork must be the direct child fork of main fork");
-        }
-        if (!profile.IsIsolated())
-        {
-            throw CRPCException(RPC_INVALID_PARAMETER, "DeFi fork must be the isolated fork");
-        }
-
         profile.defi.nMintHeight = spParam->defi.nMintheight;
         if (profile.defi.nMintHeight >= 0 && profile.defi.nMintHeight < nJointHeight + 2)
         {


### PR DESCRIPTION
Allow some rules after pr: 
 - Parent of DeFi fork **can** be any fork
 - DeFi fork **can** inherit parent fork unspent